### PR TITLE
Change cellStates logging to DEBUG

### DIFF
--- a/auctionrunner/scheduler.go
+++ b/auctionrunner/scheduler.go
@@ -303,14 +303,14 @@ func (s *Scheduler) scheduleLRPAuction(lrpAuction *auctiontypes.LRPAuction) (*au
 	if winnerCell == nil {
 		err := &rep.InsufficientResourcesError{Problems: problems}
 		s.logger.Error("lrp-auction-failed", err, lager.Data{"lrp-guid": lrpAuction.Identifier(), "lrp-instance-guid": lrpAuction.LRP.InstanceGUID, "lrp-placement-constraints": lrpAuction.LRP.PlacementConstraint, "lrp-resource": lrpAuction.LRP.Resource})
-		s.logger.Info("cells-failing-score-for-lrp", lager.Data{"states": cellStates})
+		s.logger.Debug("cells-failing-score-for-lrp", lager.Data{"states": cellStates})
 		return nil, err
 	}
 
 	err = winnerCell.ReserveLRP(&lrpAuction.LRP)
 	if err != nil {
 		s.logger.Error("lrp-failed-to-reserve-cell", err, lager.Data{"cell-guid": winnerCell.Guid, "lrp-guid": lrpAuction.Identifier(), "lrp-instance-guid": lrpAuction.LRP.InstanceGUID, "lrp-placement-constraints": lrpAuction.LRP.PlacementConstraint, "lrp-resource": lrpAuction.LRP.Resource})
-		s.logger.Info("cells-failing-score-for-lrp", lager.Data{"states": cellStates})
+		s.logger.Debug("cells-failing-score-for-lrp", lager.Data{"states": cellStates})
 		return nil, err
 	}
 

--- a/auctionrunner/scheduler_test.go
+++ b/auctionrunner/scheduler_test.go
@@ -535,6 +535,8 @@ var _ = Describe("Scheduler", func() {
 				Expect(logText).To(MatchRegexp("lrp-auction-failed.*insufficient resources: memory.*pg-4"))
 				Expect(logText).To(MatchRegexp("lrp-auction-failed.*lrp-placement-constraints.*"))
 				Expect(logText).To(MatchRegexp(".*cells-failing-score-for-lrp.*"))
+				Expect(logText).To(MatchRegexp(".*AvailableResource.*"))
+				Expect(logText).ToNot(MatchRegexp(".*LRPs.*"))
 			})
 
 			It("should mark the start auction as failed", func() {


### PR DESCRIPTION
In a very large environment (we have 660 cells and almost over 200K LRPs) this printing of the whole cellState list is massive. 

It caused issue where the auctioneer was too busy logging that it would not respond to requests and we had then more auction failures.

Moved this to "DEBUG" so normal production envs would not see the huge amount of data.

Really we do want to maybe print the AvailableResources, Rootfses, and PlacementTags and not the complete structure.  I can look at that as a secondary PR.