### PR TITLE
Reduce logging of fetched-cell-state to debug

### DIFF
--- a/auctionrunner/zone_builder.go
+++ b/auctionrunner/zone_builder.go
@@ -59,7 +59,7 @@ func fetchStateAndBuildZones(logger lager.Logger, workPool *workpool.WorkPool, c
 			lock.Lock()
 			zones[state.Zone] = append(zones[state.Zone], cell)
 			lock.Unlock()
-			logger.Info("fetched-cell-state", lager.Data{"cell-guid": guid, "duration_ns": time.Since(startTime)})
+			logger.Debug("fetched-cell-state", lager.Data{"cell-guid": guid, "duration_ns": time.Since(startTime)})
 		})
 	}
 


### PR DESCRIPTION
This log line produced a lot of noise on each auction when running in a large production env.

Changing this to DEBUG seems appropriate.