### PR TITLE
Bin Pack First Fit

### DIFF
--- a/auctionrunner/auction_runner.go
+++ b/auctionrunner/auction_runner.go
@@ -20,6 +20,7 @@ type auctionRunner struct {
 	batch                         *Batch
 	clock                         clock.Clock
 	workPool                      *workpool.WorkPool
+	binPackFirstFitWeight         float64
 	startingContainerWeight       float64
 	startingContainerCountMaximum int
 }
@@ -30,6 +31,7 @@ func New(
 	metricEmitter auctiontypes.AuctionMetricEmitterDelegate,
 	clock clock.Clock,
 	workPool *workpool.WorkPool,
+	binPackFirstFitWeight float64,
 	startingContainerWeight float64,
 	startingContainerCountMaximum int,
 ) *auctionRunner {
@@ -41,6 +43,7 @@ func New(
 		batch:                         NewBatch(clock),
 		clock:                         clock,
 		workPool:                      workPool,
+		binPackFirstFitWeight:         binPackFirstFitWeight  ,
 		startingContainerWeight:       startingContainerWeight,
 		startingContainerCountMaximum: startingContainerCountMaximum,
 	}
@@ -107,7 +110,7 @@ func (a *auctionRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) err
 				Tasks: taskAuctions,
 			}
 
-			scheduler := NewScheduler(a.workPool, zones, a.clock, logger, a.startingContainerWeight, a.startingContainerCountMaximum)
+			scheduler := NewScheduler(a.workPool, zones, a.clock, logger, a.binPackFirstFitWeight, a.startingContainerWeight, a.startingContainerCountMaximum)
 			auctionResults := scheduler.Schedule(auctionRequest)
 			logger.Info("scheduled", lager.Data{
 				"successful-lrp-start-auctions": len(auctionResults.SuccessfulLRPs),

--- a/auctionrunner/cell_test.go
+++ b/auctionrunner/cell_test.go
@@ -20,10 +20,10 @@ var _ = Describe("Cell", func() {
 
 	BeforeEach(func() {
 		client = &repfakes.FakeSimClient{}
-		emptyState := BuildCellState("cellID", "the-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
+		emptyState := BuildCellState("cellID", 0, "the-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 		emptyCell = auctionrunner.NewCell(logger, "empty-cell", client, emptyState)
 
-		state := BuildCellState("cellID", "the-zone", 100, 200, 50, false, 10, linuxOnlyRootFSProviders, []rep.LRP{
+		state := BuildCellState("cellID", 0, "the-zone", 100, 200, 50, false, 10, linuxOnlyRootFSProviders, []rep.LRP{
 			*BuildLRP("pg-1", "domain", 0, linuxRootFSURL, 10, 20, 10, []string{}),
 			*BuildLRP("pg-1", "domain", 1, linuxRootFSURL, 10, 20, 10, []string{}),
 			*BuildLRP("pg-2", "domain", 0, linuxRootFSURL, 10, 20, 10, []string{}),
@@ -69,7 +69,7 @@ var _ = Describe("Cell", func() {
 			)
 
 			JustBeforeEach(func() {
-				proxiedCellState := BuildCellState("cellID", "the-zone", proxiedCellMemory, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, proxyMemoryOverhead)
+				proxiedCellState := BuildCellState("cellID", 0, "the-zone", proxiedCellMemory, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, proxyMemoryOverhead)
 				proxiedCell = auctionrunner.NewCell(logger, "proxied-cell", client, proxiedCellState)
 				lrp = BuildLRP("pg-big", "domain", 0, linuxRootFSURL, lrpDesiredMemory, 10, 10, []string{})
 			})
@@ -127,10 +127,10 @@ var _ = Describe("Cell", func() {
 		It("factors in container usage", func() {
 			instance := BuildLRP("pg-big", "domain", 0, linuxRootFSURL, 20, 20, 10, []string{})
 
-			bigState := BuildCellState("cellID", "the-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
+			bigState := BuildCellState("cellID", 0, "the-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 			bigCell := auctionrunner.NewCell(logger, "big-cell", client, bigState)
 
-			smallState := BuildCellState("cellID", "the-zone", 100, 200, 20, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
+			smallState := BuildCellState("cellID", 0, "the-zone", 100, 200, 20, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 			smallCell := auctionrunner.NewCell(logger, "small-cell", client, smallState)
 
 			bigScore, err := bigCell.ScoreForLRP(instance, 0.0)
@@ -150,6 +150,7 @@ var _ = Describe("Cell", func() {
 
 				busyState = BuildCellState(
 					"cellID",
+					0,
 					"the-zone",
 					100,
 					200,
@@ -167,6 +168,7 @@ var _ = Describe("Cell", func() {
 
 				boredState = BuildCellState(
 					"cellID",
+					0,
 					"the-zone",
 					100,
 					200,
@@ -195,6 +197,7 @@ var _ = Describe("Cell", func() {
 
 				smallerWeightState := BuildCellState(
 					"cellID",
+					0,
 					"the-zone",
 					100,
 					200,
@@ -277,7 +280,7 @@ var _ = Describe("Cell", func() {
 			Context("because of container constraints", func() {
 				It("should error", func() {
 					instance := BuildLRP("pg-new", "domain", 0, linuxRootFSURL, 10, 10, 10, []string{})
-					zeroState := BuildCellState("cellID", "the-zone", 100, 100, 0, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
+					zeroState := BuildCellState("cellID", 0, "the-zone", 100, 100, 0, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 					zeroCell := auctionrunner.NewCell(logger, "zero-cell", client, zeroState)
 					score, err := zeroCell.ScoreForLRP(instance, 0.0)
 					Expect(score).To(BeZero())
@@ -351,10 +354,10 @@ var _ = Describe("Cell", func() {
 		It("factors in container usage", func() {
 			task := BuildTask("tg-big", "domain", linuxRootFSURL, 20, 20, 10, []string{}, []string{})
 
-			bigState := BuildCellState("cellID", "the-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
+			bigState := BuildCellState("cellID", 0, "the-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 			bigCell := auctionrunner.NewCell(logger, "big-cell", client, bigState)
 
-			smallState := BuildCellState("cellID", "the-zone", 100, 200, 20, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
+			smallState := BuildCellState("cellID", 0, "the-zone", 100, 200, 20, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 			smallCell := auctionrunner.NewCell(logger, "small-cell", client, smallState)
 
 			bigScore, err := bigCell.ScoreForTask(task, 0.0)
@@ -372,10 +375,10 @@ var _ = Describe("Cell", func() {
 			BeforeEach(func() {
 				task = BuildTask("tg-big", "domain", linuxRootFSURL, 20, 20, 20, []string{}, []string{})
 
-				busyState = BuildCellState("cellID", "the-zone", 100, 200, 50, false, 10, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
+				busyState = BuildCellState("cellID", 0, "the-zone", 100, 200, 50, false, 10, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 				busyCell = auctionrunner.NewCell(logger, "busy-cell", client, busyState)
 
-				boredState = BuildCellState("cellID", "the-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
+				boredState = BuildCellState("cellID", 0, "the-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 				boredCell = auctionrunner.NewCell(logger, "bored-cell", client, boredState)
 			})
 
@@ -420,7 +423,7 @@ var _ = Describe("Cell", func() {
 			Context("because of container constraints", func() {
 				It("should error", func() {
 					task := BuildTask("pg-new", "domain", linuxRootFSURL, 10, 10, 10, []string{}, []string{})
-					zeroState := BuildCellState("cellID", "the-zone", 100, 100, 0, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
+					zeroState := BuildCellState("cellID", 0, "the-zone", 100, 100, 0, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 					zeroCell := auctionrunner.NewCell(logger, "zero-cell", client, zeroState)
 					score, err := zeroCell.ScoreForTask(task, 0.0)
 					Expect(score).To(BeZero())

--- a/auctionrunner/cell_test.go
+++ b/auctionrunner/cell_test.go
@@ -44,17 +44,17 @@ var _ = Describe("Cell", func() {
 			smallInstance := BuildLRP("pg-small", "domain", 0, linuxRootFSURL, 10, 10, 10, []string{})
 
 			By("factoring in the amount of memory taken up by the instance")
-			bigScore, err := emptyCell.ScoreForLRP(bigInstance, 0.0)
+			bigScore, err := emptyCell.ScoreForLRP(bigInstance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
-			smallScore, err := emptyCell.ScoreForLRP(smallInstance, 0.0)
+			smallScore, err := emptyCell.ScoreForLRP(smallInstance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(smallScore).To(BeNumerically("<", bigScore))
 
 			By("factoring in the relative emptiness of Cells")
-			emptyScore, err := emptyCell.ScoreForLRP(smallInstance, 0.0)
+			emptyScore, err := emptyCell.ScoreForLRP(smallInstance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
-			score, err := cell.ScoreForLRP(smallInstance, 0.0)
+			score, err := cell.ScoreForLRP(smallInstance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(emptyScore).To(BeNumerically("<", score))
 		})
@@ -82,7 +82,7 @@ var _ = Describe("Cell", func() {
 				})
 
 				It("succeeds placing the lrp", func() {
-					score, err := proxiedCell.ScoreForLRP(lrp, 0.0)
+					score, err := proxiedCell.ScoreForLRP(lrp, 0.0, 0.0)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(score).To(BeNumerically(">", 0))
 				})
@@ -96,7 +96,7 @@ var _ = Describe("Cell", func() {
 				})
 
 				It("errors with memory placement error", func() {
-					score, err := proxiedCell.ScoreForLRP(lrp, 0.0)
+					score, err := proxiedCell.ScoreForLRP(lrp, 0.0, 0.0)
 					Expect(err).To(HaveOccurred())
 					Expect(err.Error()).To(Equal("insufficient resources: memory"))
 					Expect(score).To(BeZero())
@@ -109,17 +109,17 @@ var _ = Describe("Cell", func() {
 			smallInstance := BuildLRP("pg-small", "domain", 0, linuxRootFSURL, 10, 10, 10, []string{})
 
 			By("factoring in the amount of memory taken up by the instance")
-			bigScore, err := emptyCell.ScoreForLRP(bigInstance, 0.0)
+			bigScore, err := emptyCell.ScoreForLRP(bigInstance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
-			smallScore, err := emptyCell.ScoreForLRP(smallInstance, 0.0)
+			smallScore, err := emptyCell.ScoreForLRP(smallInstance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(smallScore).To(BeNumerically("<", bigScore))
 
 			By("factoring in the relative emptiness of Cells")
-			emptyScore, err := emptyCell.ScoreForLRP(smallInstance, 0.0)
+			emptyScore, err := emptyCell.ScoreForLRP(smallInstance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
-			score, err := cell.ScoreForLRP(smallInstance, 0.0)
+			score, err := cell.ScoreForLRP(smallInstance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(emptyScore).To(BeNumerically("<", score))
 		})
@@ -133,9 +133,9 @@ var _ = Describe("Cell", func() {
 			smallState := BuildCellState("cellID", 0, "the-zone", 100, 200, 20, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 			smallCell := auctionrunner.NewCell(logger, "small-cell", client, smallState)
 
-			bigScore, err := bigCell.ScoreForLRP(instance, 0.0)
+			bigScore, err := bigCell.ScoreForLRP(instance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
-			smallScore, err := smallCell.ScoreForLRP(instance, 0.0)
+			smallScore, err := smallCell.ScoreForLRP(instance, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(bigScore).To(BeNumerically("<", smallScore), "prefer Cells with more resources")
 		})
@@ -188,9 +188,9 @@ var _ = Describe("Cell", func() {
 			It("factors in starting containers when a weight is provided", func() {
 				startingContainerWeight := 0.25
 
-				busyScore, err := busyCell.ScoreForLRP(instance, startingContainerWeight)
+				busyScore, err := busyCell.ScoreForLRP(instance, startingContainerWeight, 0.0)
 				Expect(err).NotTo(HaveOccurred())
-				boredScore, err := boredCell.ScoreForLRP(instance, startingContainerWeight)
+				boredScore, err := boredCell.ScoreForLRP(instance, startingContainerWeight, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(busyScore).To(BeNumerically(">", boredScore), "prefer Cells that have less starting containers")
@@ -212,7 +212,7 @@ var _ = Describe("Cell", func() {
 					0,
 				)
 				smallerWeightCell := auctionrunner.NewCell(logger, "busy-cell", client, smallerWeightState)
-				smallerWeightScore, err := smallerWeightCell.ScoreForLRP(instance, startingContainerWeight-0.1)
+				smallerWeightScore, err := smallerWeightCell.ScoreForLRP(instance, startingContainerWeight-0.1, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(busyScore).To(BeNumerically(">", smallerWeightScore), "the number of starting containers is weighted")
@@ -222,9 +222,9 @@ var _ = Describe("Cell", func() {
 				instance = BuildLRP("HA", "domain", 1, linuxRootFSURL, 20, 20, 10, []string{})
 				startingContainerWeight := 0.25
 
-				busyScore, err := busyCell.ScoreForLRP(instance, startingContainerWeight)
+				busyScore, err := busyCell.ScoreForLRP(instance, startingContainerWeight, 0.0)
 				Expect(err).NotTo(HaveOccurred())
-				boredScore, err := boredCell.ScoreForLRP(instance, startingContainerWeight)
+				boredScore, err := boredCell.ScoreForLRP(instance, startingContainerWeight, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(busyScore).To(BeNumerically("<", boredScore), "prefer Cells that do not have an instance of self already running")
@@ -233,9 +233,9 @@ var _ = Describe("Cell", func() {
 			It("ignores starting containers when a weight is not provided", func() {
 				startingContainerWeight := 0.0
 
-				busyScore, err := busyCell.ScoreForLRP(instance, startingContainerWeight)
+				busyScore, err := busyCell.ScoreForLRP(instance, startingContainerWeight, 0.0)
 				Expect(err).NotTo(HaveOccurred())
-				boredScore, err := boredCell.ScoreForLRP(instance, startingContainerWeight)
+				boredScore, err := boredCell.ScoreForLRP(instance, startingContainerWeight, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(busyScore).To(BeNumerically("==", boredScore), "ignore how many starting Containers a cell has")
@@ -247,11 +247,11 @@ var _ = Describe("Cell", func() {
 			instanceWithOneMatch := BuildLRP("pg-2", "domain", 1, linuxRootFSURL, 10, 10, 10, []string{})
 			instanceWithNoMatches := BuildLRP("pg-new", "domain", 0, linuxRootFSURL, 10, 10, 10, []string{})
 
-			twoMatchesScore, err := cell.ScoreForLRP(instanceWithTwoMatches, 0.0)
+			twoMatchesScore, err := cell.ScoreForLRP(instanceWithTwoMatches, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
-			oneMatchesScore, err := cell.ScoreForLRP(instanceWithOneMatch, 0.0)
+			oneMatchesScore, err := cell.ScoreForLRP(instanceWithOneMatch, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
-			noMatchesScore, err := cell.ScoreForLRP(instanceWithNoMatches, 0.0)
+			noMatchesScore, err := cell.ScoreForLRP(instanceWithNoMatches, 0.0, 0.0)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(noMatchesScore).To(BeNumerically("<", oneMatchesScore))
@@ -262,7 +262,7 @@ var _ = Describe("Cell", func() {
 			Context("because of memory constraints", func() {
 				It("should error", func() {
 					massiveMemoryInstance := BuildLRP("pg-new", "domain", 0, linuxRootFSURL, 10000, 10, 1024, []string{})
-					score, err := cell.ScoreForLRP(massiveMemoryInstance, 0.0)
+					score, err := cell.ScoreForLRP(massiveMemoryInstance, 0.0, 0.0)
 					Expect(score).To(BeZero())
 					Expect(err).To(MatchError("insufficient resources: memory"))
 				})
@@ -271,7 +271,7 @@ var _ = Describe("Cell", func() {
 			Context("because of disk constraints", func() {
 				It("should error", func() {
 					massiveDiskInstance := BuildLRP("pg-new", "domain", 0, linuxRootFSURL, 10, 10000, 1024, []string{})
-					score, err := cell.ScoreForLRP(massiveDiskInstance, 0.0)
+					score, err := cell.ScoreForLRP(massiveDiskInstance, 0.0, 0.0)
 					Expect(score).To(BeZero())
 					Expect(err).To(MatchError("insufficient resources: disk"))
 				})
@@ -282,7 +282,7 @@ var _ = Describe("Cell", func() {
 					instance := BuildLRP("pg-new", "domain", 0, linuxRootFSURL, 10, 10, 10, []string{})
 					zeroState := BuildCellState("cellID", 0, "the-zone", 100, 100, 0, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0)
 					zeroCell := auctionrunner.NewCell(logger, "zero-cell", client, zeroState)
-					score, err := zeroCell.ScoreForLRP(instance, 0.0)
+					score, err := zeroCell.ScoreForLRP(instance, 0.0, 0.0)
 					Expect(score).To(BeZero())
 					Expect(err).To(MatchError("insufficient resources: containers"))
 				})
@@ -439,12 +439,12 @@ var _ = Describe("Cell", func() {
 				instance := BuildLRP("pg-test", "domain", 0, linuxRootFSURL, 10, 10, 10, []string{})
 				instanceToAdd := BuildLRP("pg-new", "domain", 0, linuxRootFSURL, 10, 10, 10, []string{})
 
-				initialScore, err := cell.ScoreForLRP(instance, 0.0)
+				initialScore, err := cell.ScoreForLRP(instance, 0.0, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(cell.ReserveLRP(instanceToAdd)).To(Succeed())
 
-				subsequentScore, err := cell.ScoreForLRP(instance, 0.0)
+				subsequentScore, err := cell.ScoreForLRP(instance, 0.0, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(initialScore).To(BeNumerically("<", subsequentScore), "the score should have gotten worse")
 			})
@@ -454,20 +454,20 @@ var _ = Describe("Cell", func() {
 				instanceWithMatchingProcessGuid := BuildLRP("pg-new", "domain", 1, linuxRootFSURL, 10, 10, 10, []string{})
 				instanceToAdd := BuildLRP("pg-new", "domain", 0, linuxRootFSURL, 10, 10, 10, []string{})
 
-				initialScore, err := cell.ScoreForLRP(instance, 0.0)
+				initialScore, err := cell.ScoreForLRP(instance, 0.0, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 
-				initialScoreForInstanceWithMatchingProcessGuid, err := cell.ScoreForLRP(instanceWithMatchingProcessGuid, 0.0)
+				initialScoreForInstanceWithMatchingProcessGuid, err := cell.ScoreForLRP(instanceWithMatchingProcessGuid, 0.0, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(initialScore).To(BeNumerically("==", initialScoreForInstanceWithMatchingProcessGuid))
 
 				Expect(cell.ReserveLRP(instanceToAdd)).To(Succeed())
 
-				subsequentScore, err := cell.ScoreForLRP(instance, 0.0)
+				subsequentScore, err := cell.ScoreForLRP(instance, 0.0, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 
-				subsequentScoreForInstanceWithMatchingProcessGuid, err := cell.ScoreForLRP(instanceWithMatchingProcessGuid, 0.0)
+				subsequentScoreForInstanceWithMatchingProcessGuid, err := cell.ScoreForLRP(instanceWithMatchingProcessGuid, 0.0, 0.0)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(initialScore).To(BeNumerically("<", subsequentScore), "the score should have gotten worse")

--- a/auctionrunner/scheduler.go
+++ b/auctionrunner/scheduler.go
@@ -45,6 +45,7 @@ type Scheduler struct {
 	zones                         map[string]Zone
 	clock                         clock.Clock
 	logger                        lager.Logger
+	binPackFirstFitWeight         float64
 	startingContainerWeight       float64
 	startingContainerCountMaximum int // <=0 means no limit
 }
@@ -54,6 +55,7 @@ func NewScheduler(
 	zones map[string]Zone,
 	clock clock.Clock,
 	logger lager.Logger,
+	binPackFirstFitWeight float64,
 	startingContainerWeight float64,
 	startingContainerCountMaximum int,
 ) *Scheduler {
@@ -62,6 +64,7 @@ func NewScheduler(
 		zones:                         zones,
 		clock:                         clock,
 		logger:                        logger,
+		binPackFirstFitWeight:         binPackFirstFitWeight,
 		startingContainerWeight:       startingContainerWeight,
 		startingContainerCountMaximum: startingContainerCountMaximum,
 	}
@@ -295,7 +298,7 @@ func (s *Scheduler) scheduleLRPAuction(lrpAuction *auctiontypes.LRPAuction) (*au
 
 	for zoneIndex, lrpByZone := range sortedZones {
 		for _, cell := range lrpByZone.zone {
-			score, err := cell.ScoreForLRP(&lrpAuction.LRP, s.startingContainerWeight)
+			score, err := cell.ScoreForLRP(&lrpAuction.LRP, s.startingContainerWeight, s.binPackFirstFitWeight)
 			if err != nil {
 				cellStates[cell.Guid] = NewCellResourceState(cell.State())
 				removeNonApplicableProblems(problems, err)

--- a/auctionrunner/scheduler_test.go
+++ b/auctionrunner/scheduler_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Scheduler", func() {
 					logger,
 					"A-cell",
 					clients["A-cell"],
-					BuildCellState("cellID", "A-zone", 100, 100, 100, false, inflightStartsPerCell, linuxOnlyRootFSProviders, []rep.LRP{
+					BuildCellState("cellID", 0, "A-zone", 100, 100, 100, false, inflightStartsPerCell, linuxOnlyRootFSProviders, []rep.LRP{
 						*BuildLRP("pg-1", "domain", 0, "", 10, 10, 10, []string{}),
 						*BuildLRP("pg-2", "domain", 0, "", 10, 10, 10, []string{}),
 					}, []string{}, []string{}, []string{}, 0),
@@ -101,7 +101,7 @@ var _ = Describe("Scheduler", func() {
 					logger,
 					"B-cell",
 					clients["B-cell"],
-					BuildCellState("cellID", "B-zone", 100, 100, 100, false, inflightStartsPerCell, linuxOnlyRootFSProviders, []rep.LRP{
+					BuildCellState("cellID", 0, "B-zone", 100, 100, 100, false, inflightStartsPerCell, linuxOnlyRootFSProviders, []rep.LRP{
 						*BuildLRP("pg-3", "domain", 0, "", 10, 10, 10, []string{}),
 					}, []string{}, []string{}, []string{}, 0),
 				),
@@ -150,7 +150,7 @@ var _ = Describe("Scheduler", func() {
 					logger,
 					"A-cell",
 					clients["A-cell"],
-					BuildCellState("cellID", "A-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+					BuildCellState("cellID", 0, "A-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 						*BuildLRP("pg-1", "domain", 0, "", 10, 10, 10, []string{}),
 						*BuildLRP("pg-2", "domain", 0, "", 10, 10, 10, []string{}),
 					}, []string{}, []string{}, []string{}, 0),
@@ -163,7 +163,7 @@ var _ = Describe("Scheduler", func() {
 					logger,
 					"B-cell",
 					clients["B-cell"],
-					BuildCellState("cellID", "B-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+					BuildCellState("cellID", 0, "B-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 						*BuildLRP("pg-3", "domain", 0, "", 10, 10, 10, []string{}),
 					}, []string{}, []string{}, []string{}, 0),
 				),
@@ -178,7 +178,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"C-cell",
 						clients["C-cell"],
-						BuildCellState("cellID", "C-zone", 100, 100, 100, false, 0, windowsOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "C-zone", 100, 100, 100, false, 0, windowsOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-win-1", "domain", 0, "", 10, 10, 10, []string{}),
 						}, []string{}, []string{}, []string{}, 0),
 					),
@@ -224,7 +224,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"A-cell",
 						clients["A-cell"],
-						BuildCellState("cellID", "A-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "A-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-win-1", "domain", 0, "", 10, 10, 10, []string{}),
 						}, []string{"driver-1", "driver-2"}, []string{}, []string{}, 0),
 					),
@@ -236,7 +236,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"B-cell",
 						clients["B-cell"],
-						BuildCellState("cellID", "B-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "B-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-win-1", "domain", 0, "", 10, 10, 10, []string{}),
 						}, []string{"driver-3"}, []string{}, []string{}, 0),
 					),
@@ -295,7 +295,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"cell-z1-1",
 						clients["cell-z1-1"],
-						BuildCellState("cellID", "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-5", "domain", 0, "", 10, 10, 10, []string{"quack", "moo"}),
 						}, []string{}, []string{"quack", "moo"}, []string{"chirp"}, 0),
 					),
@@ -303,7 +303,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"cell-z1-2",
 						clients["cell-z1-2"],
-						BuildCellState("cellID", "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-5", "domain", 0, "", 10, 10, 10, []string{}),
 						}, []string{}, []string{}, []string{}, 0),
 					),
@@ -315,7 +315,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"cell-z2-1",
 						clients["cell-z2-1"],
-						BuildCellState("cellID", "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-5", "domain", 0, "", 10, 10, 10, []string{"quack"}),
 						}, []string{}, []string{"quack"}, []string{"chirp", "baa"}, 0),
 					),
@@ -323,7 +323,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"cell-z2-2",
 						clients["cell-z2-2"],
-						BuildCellState("cellID", "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-5", "domain", 0, "", 10, 10, 10, []string{"quack", "moo", "oink"}),
 						}, []string{}, []string{"quack", "moo", "oink"}, []string{}, 0),
 					),
@@ -569,7 +569,7 @@ var _ = Describe("Scheduler", func() {
 							logger,
 							"C-cell",
 							clients["C-cell"],
-							BuildCellState("cellID", "C-zone", 1200, 5, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{}, []string{}, []string{}, []string{}, 0),
+							BuildCellState("cellID", 0, "C-zone", 1200, 5, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{}, []string{}, []string{}, []string{}, 0),
 						),
 					}
 				})
@@ -590,13 +590,13 @@ var _ = Describe("Scheduler", func() {
 
 		BeforeEach(func() {
 			clients["A-cell"] = &repfakes.FakeSimClient{}
-			zones["A-zone"] = auctionrunner.Zone{auctionrunner.NewCell(logger, "A-cell", clients["A-cell"], BuildCellState("cellID", "A-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+			zones["A-zone"] = auctionrunner.Zone{auctionrunner.NewCell(logger, "A-cell", clients["A-cell"], BuildCellState("cellID", 0, "A-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 				*BuildLRP("does-not-matter", "domain", 0, "", 10, 10, 10, []string{}),
 				*BuildLRP("does-not-matter", "domain", 0, "", 10, 10, 10, []string{}),
 			}, []string{"driver-1", "driver-2"}, []string{}, []string{}, 0))}
 
 			clients["B-cell"] = &repfakes.FakeSimClient{}
-			zones["B-zone"] = auctionrunner.Zone{auctionrunner.NewCell(logger, "B-cell", clients["B-cell"], BuildCellState("cellID", "B-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+			zones["B-zone"] = auctionrunner.Zone{auctionrunner.NewCell(logger, "B-cell", clients["B-cell"], BuildCellState("cellID", 0, "B-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 				*BuildLRP("does-not-matter", "domain", 0, "", 10, 10, 10, []string{}),
 			}, []string{"driver-3"}, []string{}, []string{}, 0))}
 
@@ -612,7 +612,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"C-cell",
 						clients["C-cell"],
-						BuildCellState("cellID", "C-zone", 100, 100, 100, false, 0, windowsOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "C-zone", 100, 100, 100, false, 0, windowsOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("tg-win-1", "domain", 0, "", 10, 10, 10, []string{}),
 						}, []string{}, []string{}, []string{}, 0),
 					),
@@ -702,7 +702,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"cell-z1-1",
 						clients["cell-z1-1"],
-						BuildCellState("cellID", "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-5", "domain", 0, "", 10, 10, 10, []string{"quack", "moo"}),
 						}, []string{}, []string{"quack", "moo"}, []string{}, 0),
 					),
@@ -710,7 +710,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"cell-z1-2",
 						clients["cell-z1-2"],
-						BuildCellState("cellID", "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-5", "domain", 0, "", 10, 10, 10, []string{}),
 						}, []string{}, []string{}, []string{}, 0),
 					),
@@ -722,7 +722,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"cell-z2-1",
 						clients["cell-z2-1"],
-						BuildCellState("cellID", "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-5", "domain", 0, "", 10, 10, 10, []string{"quack"}),
 						}, []string{}, []string{"quack"}, []string{}, 0),
 					),
@@ -730,7 +730,7 @@ var _ = Describe("Scheduler", func() {
 						logger,
 						"cell-z2-2",
 						clients["cell-z2-2"],
-						BuildCellState("cellID", "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+						BuildCellState("cellID", 0, "z1", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 							*BuildLRP("pg-5", "domain", 0, "", 10, 10, 10, []string{"quack", "moo", "oink"}),
 						}, []string{}, []string{"quack", "moo", "oink"}, []string{}, 0),
 					),
@@ -863,7 +863,7 @@ var _ = Describe("Scheduler", func() {
 							logger,
 							"C-cell",
 							clients["C-cell"],
-							BuildCellState("cellID", "C-zone", 1200, 5, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{}, []string{}, []string{}, []string{}, 0),
+							BuildCellState("cellID", 0, "C-zone", 1200, 5, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{}, []string{}, []string{}, []string{}, 0),
 						),
 					}
 				})
@@ -927,13 +927,13 @@ var _ = Describe("Scheduler", func() {
 	Describe("a comprehensive scenario", func() {
 		BeforeEach(func() {
 			clients["A-cell"] = &repfakes.FakeSimClient{}
-			zones["A-zone"] = auctionrunner.Zone{auctionrunner.NewCell(logger, "A-cell", clients["A-cell"], BuildCellState("cellID", "A-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+			zones["A-zone"] = auctionrunner.Zone{auctionrunner.NewCell(logger, "A-cell", clients["A-cell"], BuildCellState("cellID", 0, "A-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 				*BuildLRP("pg-1", "domain", 0, "", 10, 10, 10, []string{}),
 				*BuildLRP("pg-2", "domain", 0, "", 10, 10, 10, []string{}),
 			}, []string{}, []string{}, []string{}, 0))}
 
 			clients["B-cell"] = &repfakes.FakeSimClient{}
-			zones["B-zone"] = auctionrunner.Zone{auctionrunner.NewCell(logger, "B-cell", clients["B-cell"], BuildCellState("cellID", "B-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
+			zones["B-zone"] = auctionrunner.Zone{auctionrunner.NewCell(logger, "B-cell", clients["B-cell"], BuildCellState("cellID", 0, "B-zone", 100, 100, 100, false, 0, linuxOnlyRootFSProviders, []rep.LRP{
 				*BuildLRP("pg-3", "domain", 0, "", 10, 10, 10, []string{}),
 				*BuildLRP("pg-4", "domain", 0, "", 20, 20, 10, []string{}),
 			}, []string{}, []string{}, []string{}, 0))}
@@ -1051,7 +1051,7 @@ var _ = Describe("Scheduler", func() {
 
 		JustBeforeEach(func() {
 			zones["zone"] = auctionrunner.Zone{
-				auctionrunner.NewCell(logger, "cell", clients["cell"], BuildCellState("cellID", "zone", memory, 1000, 1000, false, 0, linuxOnlyRootFSProviders, []rep.LRP{}, []string{}, []string{}, []string{}, 0)),
+				auctionrunner.NewCell(logger, "cell", clients["cell"], BuildCellState("cellID", 0, "zone", memory, 1000, 1000, false, 0, linuxOnlyRootFSProviders, []rep.LRP{}, []string{}, []string{}, []string{}, 0)),
 			}
 
 			auctionRequest := auctiontypes.AuctionRequest{

--- a/auctionrunner/scheduler_test.go
+++ b/auctionrunner/scheduler_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Scheduler", func() {
 
 		logger = lagertest.NewTestLogger("fakelogger")
 
-		scheduler = auctionrunner.NewScheduler(workPool, map[string]auctionrunner.Zone{}, clock, logger, 0.0, 0)
+		scheduler = auctionrunner.NewScheduler(workPool, map[string]auctionrunner.Zone{}, clock, logger, 0.0, 0.0, 0)
 	})
 
 	AfterEach(func() {
@@ -119,7 +119,7 @@ var _ = Describe("Scheduler", func() {
 				taskAuction1 := BuildTaskAuction(BuildTask("tg-1", "domain", linuxRootFSURL, 10, 10, 10, []string{}, []string{}), clock.Now())
 				taskAuction2 := BuildTaskAuction(BuildTask("tg-2", "domain", linuxRootFSURL, 10, 10, 10, []string{}, []string{}), clock.Now())
 
-				scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, startingContainerCountMaximum)
+				scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, startingContainerCountMaximum)
 				startLRPAuctions := []auctiontypes.LRPAuction{pg70, pg71}
 				startTaskAuctions := []auctiontypes.TaskAuction{taskAuction1, taskAuction2}
 				auctionRequest = auctiontypes.AuctionRequest{LRPs: startLRPAuctions, Tasks: startTaskAuctions}
@@ -193,7 +193,7 @@ var _ = Describe("Scheduler", func() {
 				Context("when it picks a winner", func() {
 					BeforeEach(func() {
 						clock.Increment(time.Minute)
-						s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+						s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 						results = s.Schedule(auctiontypes.AuctionRequest{LRPs: []auctiontypes.LRPAuction{startAuction}})
 					})
 
@@ -248,7 +248,7 @@ var _ = Describe("Scheduler", func() {
 					startAuction = BuildLRPAuction("pg-4", "domain", 1, linuxRootFSURL, 10, 10, 10, clock.Now(), []string{"driver-1", "driver-3"}, []string{})
 					clock.Increment(time.Minute)
 
-					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 					results = s.Schedule(auctiontypes.AuctionRequest{LRPs: []auctiontypes.LRPAuction{startAuction}})
 				})
 
@@ -264,7 +264,7 @@ var _ = Describe("Scheduler", func() {
 					startAuction = BuildLRPAuction("pg-4", "domain", 1, linuxRootFSURL, 10, 10, 10, clock.Now(), []string{"driver-3"}, []string{})
 					clock.Increment(time.Minute)
 
-					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 					results = s.Schedule(auctiontypes.AuctionRequest{LRPs: []auctiontypes.LRPAuction{startAuction}})
 				})
 
@@ -337,7 +337,7 @@ var _ = Describe("Scheduler", func() {
 					LRPs:  []auctiontypes.LRPAuction{startAuction},
 					Tasks: []auctiontypes.TaskAuction{},
 				}
-				scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, defaultStartingContainerCountMaximum)
+				scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, defaultStartingContainerCountMaximum)
 			})
 
 			It("places the lrp on a cell with matching placement tags", func() {
@@ -394,7 +394,7 @@ var _ = Describe("Scheduler", func() {
 				BeforeEach(func() {
 					clock.Increment(time.Minute)
 
-					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 					results = s.Schedule(auctiontypes.AuctionRequest{LRPs: []auctiontypes.LRPAuction{startAuction}})
 				})
 
@@ -423,7 +423,7 @@ var _ = Describe("Scheduler", func() {
 			Context("when it picks a winner", func() {
 				BeforeEach(func() {
 					clock.Increment(time.Minute)
-					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 					results = s.Schedule(auctiontypes.AuctionRequest{LRPs: []auctiontypes.LRPAuction{startAuction}})
 				})
 
@@ -452,7 +452,7 @@ var _ = Describe("Scheduler", func() {
 				clients["B-cell"].PerformReturns(rep.Work{LRPs: []rep.LRP{startAuction.LRP}}, nil)
 
 				clock.Increment(time.Minute)
-				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 				results = s.Schedule(auctiontypes.AuctionRequest{LRPs: []auctiontypes.LRPAuction{startAuction}})
 			})
 
@@ -487,7 +487,7 @@ var _ = Describe("Scheduler", func() {
 				})
 
 				It("only starts the maximum number of containers", func() {
-					scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, startingContainerCountMaximum)
+					scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, startingContainerCountMaximum)
 					results = scheduler.Schedule(auctiontypes.AuctionRequest{LRPs: startAuctions})
 
 					Expect(results.SuccessfulLRPs).To(HaveLen(startingContainerCountMaximum))
@@ -502,7 +502,7 @@ var _ = Describe("Scheduler", func() {
 				})
 
 				It("should behave as if there is no limit", func() {
-					scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, startingContainerCountMaximum)
+					scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, startingContainerCountMaximum)
 					results = scheduler.Schedule(auctiontypes.AuctionRequest{LRPs: startAuctions})
 
 					Expect(results.SuccessfulLRPs).To(HaveLen(len(startAuctions)))
@@ -521,7 +521,7 @@ var _ = Describe("Scheduler", func() {
 			JustBeforeEach(func() {
 				startAuction = BuildLRPAuction("pg-4", "domain", 0, linuxRootFSURL, 1000, requestedDisk, 10, clock.Now(), []string{}, []string{})
 				clock.Increment(time.Minute)
-				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 				results = s.Schedule(auctiontypes.AuctionRequest{LRPs: []auctiontypes.LRPAuction{startAuction}})
 			})
 
@@ -627,7 +627,7 @@ var _ = Describe("Scheduler", func() {
 				Context("when it picks a winner", func() {
 					BeforeEach(func() {
 						clock.Increment(time.Minute)
-						s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+						s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 						results = s.Schedule(auctiontypes.AuctionRequest{Tasks: []auctiontypes.TaskAuction{taskAuction}})
 					})
 
@@ -656,7 +656,7 @@ var _ = Describe("Scheduler", func() {
 					taskAuction = BuildTaskAuction(BuildTask("tg-1", "domain", linuxRootFSURL, 10, 10, 10, []string{"no-compatible-driver"}, []string{}), clock.Now())
 					clock.Increment(time.Minute)
 
-					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 					results = s.Schedule(auctiontypes.AuctionRequest{Tasks: []auctiontypes.TaskAuction{taskAuction}})
 				})
 
@@ -672,7 +672,7 @@ var _ = Describe("Scheduler", func() {
 					taskAuction = BuildTaskAuction(BuildTask("tg-1", "domain", linuxRootFSURL, 10, 10, 10, []string{"driver-1", "driver-2"}, []string{}), clock.Now())
 					clock.Increment(time.Minute)
 
-					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+					s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 					results = s.Schedule(auctiontypes.AuctionRequest{Tasks: []auctiontypes.TaskAuction{taskAuction}})
 				})
 
@@ -744,7 +744,7 @@ var _ = Describe("Scheduler", func() {
 					LRPs:  []auctiontypes.LRPAuction{},
 					Tasks: []auctiontypes.TaskAuction{taskAuction},
 				}
-				scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, defaultStartingContainerCountMaximum)
+				scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, defaultStartingContainerCountMaximum)
 			})
 
 			It("places the task on a cell with matching placement tags", func() {
@@ -775,7 +775,7 @@ var _ = Describe("Scheduler", func() {
 
 		Context("when it picks a winner", func() {
 			BeforeEach(func() {
-				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 				results = s.Schedule(auctiontypes.AuctionRequest{Tasks: []auctiontypes.TaskAuction{taskAuction}})
 			})
 
@@ -800,7 +800,7 @@ var _ = Describe("Scheduler", func() {
 		Context("when the cell rejects the task", func() {
 			BeforeEach(func() {
 				clients["B-cell"].PerformReturns(rep.Work{Tasks: []rep.Task{taskAuction.Task}}, nil)
-				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 				results = s.Schedule(auctiontypes.AuctionRequest{Tasks: []auctiontypes.TaskAuction{taskAuction}})
 			})
 
@@ -823,7 +823,7 @@ var _ = Describe("Scheduler", func() {
 			JustBeforeEach(func() {
 				taskAuction = BuildTaskAuction(BuildTask("tg-1", "domain", linuxRootFSURL, 1000, requestedDisk, 10, []string{}, []string{}), clock.Now())
 				clock.Increment(time.Minute)
-				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 				results = s.Schedule(auctiontypes.AuctionRequest{Tasks: []auctiontypes.TaskAuction{taskAuction}})
 			})
 
@@ -889,7 +889,7 @@ var _ = Describe("Scheduler", func() {
 				taskAuction3 := BuildTaskAuction(BuildTask("tg-3", "domain", linuxRootFSURL, 10, 10, 10, []string{}, []string{}), clock.Now())
 				taskAuction4 := BuildTaskAuction(BuildTask("tg-4", "domain", linuxRootFSURL, 10, 10, 10, []string{}, []string{}), clock.Now())
 
-				scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, startingContainerCountMaximum)
+				scheduler = auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, startingContainerCountMaximum)
 				startAuctions = []auctiontypes.TaskAuction{taskAuction1, taskAuction2, taskAuction3, taskAuction4}
 			})
 
@@ -904,7 +904,7 @@ var _ = Describe("Scheduler", func() {
 			BeforeEach(func() {
 				taskAuction = BuildTaskAuction(BuildTask("tg-1", "domain", "unsupported:rootfs", 100, 100, 10, []string{}, []string{}), clock.Now())
 				clock.Increment(time.Minute)
-				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+				s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 				results = s.Schedule(auctiontypes.AuctionRequest{Tasks: []auctiontypes.TaskAuction{taskAuction}})
 			})
 
@@ -978,7 +978,7 @@ var _ = Describe("Scheduler", func() {
 				Tasks: []auctiontypes.TaskAuction{taskAuction1, taskAuction2, taskAuctionNope},
 			}
 
-			s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+			s := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 			results = s.Schedule(auctionRequest)
 
 			Expect(clients["A-cell"].PerformCallCount()).To(Equal(1))
@@ -1059,7 +1059,7 @@ var _ = Describe("Scheduler", func() {
 				Tasks: tasks,
 			}
 
-			scheduler := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0)
+			scheduler := auctionrunner.NewScheduler(workPool, zones, clock, logger, 0.0, 0.0, 0)
 			results = scheduler.Schedule(auctionRequest)
 		})
 

--- a/auctionrunner/test_helpers_test.go
+++ b/auctionrunner/test_helpers_test.go
@@ -134,6 +134,7 @@ var windowsOnlyRootFSProviders = rep.RootFSProviders{models.PreloadedRootFSSchem
 
 func BuildCellState(
 	cellID string,
+    cellIndex int,
 	zone string,
 	memoryMB int32,
 	diskMB int32,
@@ -160,6 +161,7 @@ func BuildCellState(
 
 	return rep.NewCellState(
 		cellID,
+        cellIndex,
 		"https://foo.cell.service.cf.internal",
 		rootFSProviders,
 		availableResources,

--- a/auctionrunner/zone_builder_test.go
+++ b/auctionrunner/zone_builder_test.go
@@ -101,9 +101,9 @@ var _ = Describe("ZoneBuilder", func() {
 			"C": repC,
 		}
 
-		repA.StateReturns(BuildCellState("A", "the-zone", 100, 200, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
-		repB.StateReturns(BuildCellState("B", "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
-		repC.StateReturns(BuildCellState("C", "other-zone", 100, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
+		repA.StateReturns(BuildCellState("A", 0, "the-zone", 100, 200, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
+		repB.StateReturns(BuildCellState("B", 0, "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
+		repC.StateReturns(BuildCellState("C", 0, "other-zone", 100, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
 
 		metricEmitter = new(fakes.FakeAuctionMetricEmitterDelegate)
 	})
@@ -144,7 +144,7 @@ var _ = Describe("ZoneBuilder", func() {
 
 	Context("when cells are evacuating", func() {
 		BeforeEach(func() {
-			repB.StateReturns(BuildCellState("B", "the-zone", 10, 10, 100, true, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
+			repB.StateReturns(BuildCellState("B", 0, "the-zone", 10, 10, 100, true, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
 		})
 
 		It("does not include them in the map", func() {
@@ -170,7 +170,7 @@ var _ = Describe("ZoneBuilder", func() {
 
 	Context("when a cell ID does not match the cell state ID", func() {
 		BeforeEach(func() {
-			repB.StateReturns(BuildCellState("badCellID", "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
+			repB.StateReturns(BuildCellState("badCellID", 0, "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
 		})
 
 		It("does not include that cell in the map", func() {
@@ -188,7 +188,7 @@ var _ = Describe("ZoneBuilder", func() {
 
 		Context("when the cell id is empty", func() {
 			BeforeEach(func() {
-				repB.StateReturns(BuildCellState("", "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
+				repB.StateReturns(BuildCellState("", 0, "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), nil)
 			})
 
 			It("includes that cell in the map", func() {
@@ -219,7 +219,7 @@ var _ = Describe("ZoneBuilder", func() {
 
 	Context("when a client fails", func() {
 		BeforeEach(func() {
-			repB.StateReturns(BuildCellState("B", "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), errors.New("boom"))
+			repB.StateReturns(BuildCellState("B", 0, "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), errors.New("boom"))
 		})
 
 		It("does not include the client in the map", func() {
@@ -251,17 +251,17 @@ var _ = Describe("ZoneBuilder", func() {
 
 	Context("when clients are slow to respond", func() {
 		BeforeEach(func() {
-			repA.StateReturns(BuildCellState("A", "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), errors.New("timeout"))
+			repA.StateReturns(BuildCellState("A", 0, "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), errors.New("timeout"))
 			repA.StateClientTimeoutReturns(5 * time.Second)
 			repA.SetStateClientStub = func(client *http.Client) {
 				repA.StateClientTimeoutReturns(client.Timeout)
 			}
-			repB.StateReturns(BuildCellState("B", "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), errors.New("timeout"))
+			repB.StateReturns(BuildCellState("B", 0, "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), errors.New("timeout"))
 			repB.StateClientTimeoutReturns(2 * time.Second)
 			repB.SetStateClientStub = func(client *http.Client) {
 				repB.StateClientTimeoutReturns(client.Timeout)
 			}
-			repC.StateReturns(BuildCellState("C", "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), errors.New("timeout"))
+			repC.StateReturns(BuildCellState("C", 0, "the-zone", 10, 10, 100, false, 0, linuxOnlyRootFSProviders, nil, []string{}, []string{}, []string{}, 0), errors.New("timeout"))
 			repC.StateClientTimeoutReturns(4 * time.Second)
 			repC.SetStateClientStub = func(client *http.Client) {
 				repC.StateClientTimeoutReturns(client.Timeout)


### PR DESCRIPTION
This PR is part of multiple PRs across [rep](https://github.com/cloudfoundry/rep), [auctioneer](https://github.com/cloudfoundry/auctioneer) and [auction](https://github.com/cloudfoundry/auction) to add an optional weighted bin pack first fit component to the scheduling algorithm of Cloud Foundry Diego for scheduling LRPs.

PRs/issues involved:
* [rep#30](https://github.com/cloudfoundry/rep/pull/30)
* [auctioneer#8](https://github.com/cloudfoundry/auctioneer/pull/8)
* [auction#8](https://github.com/cloudfoundry/auction/pull/8)
* [diego-release#448](https://github.com/cloudfoundry/diego-release/pull/448)

### What is this change about?

These PRs combined introduce a new setting for auctioneer:
```
diego.auctioneer.bin_pack_first_fit_weight
  description: "Factor to bias against BOSH instance index number of a cell. Instead of spreading containers equally across all cell
s, cells with a lower index number will be deployed to first when this setting is > 0. (0.0 - 1.0)"
  default: 0.0
```

When `bin_pack_first_fit_weight` is set to a value > 0, it will make diego-cells with a lower BOSH instance index number more attractive to deploy LRPs to by adding "weight x diego-cell index" to the score of a diego-cell. Diego-cells will be filled up more instead spreading the LRPs across all diego-cells equally.

Setting `bin_pack_first_fit_weight` to 0.0 (the default) will effectively disable the optional weighted bin pack first fit component. Everything still keeps working as it was previously.

### What problem it is trying to solve?

With the current deployment algorithm in diego it spreads the LRPs across all diego-cell instances equally. At Mendix we have 64GB memory diego-cells. We need to have the possibility for our customers to deploy 16G containers at all times. This means that we need to have at least 1 diego-cell with 16G memory available at all times. When the LRPs are spread equally you end up with a situation where on average 25% (16/64) of the memory on all our diego-cells is not used.

### What is the impact if the change is not made?

In our case 25% of our diego-cell resources are wasted. We have been running a diego-release with these changes on top for the past months in our production Cloud Foundry foundations. We are saving ten-thousands of $$ monthly on AWS EC2 costs.

### How should this change be described in diego-release release notes?

auctioneer
* Add an optional weighted bin pack first fit component to the scheduling algorithm of Cloud Foundry Diego for scheduling LRPs

### Please provide any contextual information.

Blog post with more information: https://cloud-infra.engineer/saving-costs-with-a-new-scheduler-in-cloud-foundry-diego/

### Tag your pair, your PM, and/or team!

I'm not sure who to tag.