### PR TITLE
Cell index normalization

### DIFF
--- a/auctionrunner/auction_runner.go
+++ b/auctionrunner/auction_runner.go
@@ -33,7 +33,6 @@ func New(
 	clock clock.Clock,
 	workPool *workpool.WorkPool,
 	binPackFirstFitWeight float64,
-	// Add a use cell index normalization boolean flag
 	startingContainerWeight float64,
 	startingContainerCountMaximum int,
 	useNormalisedCellIndices bool,
@@ -78,7 +77,6 @@ func (a *auctionRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) err
 
 			logger.Info("fetching-zone-state")
 			fetchStatesStartTime := time.Now()
-			// Add a use cell index normalization boolean flag
 			zones := FetchStateAndBuildZones(logger, a.workPool, clients, a.metricEmitter, a.useNormalisedCellIndices)
 			fetchStateDuration := time.Since(fetchStatesStartTime)
 			err = a.metricEmitter.FetchStatesCompleted(fetchStateDuration)

--- a/auctionrunner/auction_runner.go
+++ b/auctionrunner/auction_runner.go
@@ -23,6 +23,7 @@ type auctionRunner struct {
 	binPackFirstFitWeight         float64
 	startingContainerWeight       float64
 	startingContainerCountMaximum int
+	useNormalisedCellIndices      bool
 }
 
 func New(
@@ -35,10 +36,10 @@ func New(
 	// Add a use cell index normalization boolean flag
 	startingContainerWeight float64,
 	startingContainerCountMaximum int,
+	useNormalisedCellIndices bool,
 ) *auctionRunner {
 	return &auctionRunner{
-		logger: logger,
-
+		logger:                        logger,
 		delegate:                      delegate,
 		metricEmitter:                 metricEmitter,
 		batch:                         NewBatch(clock),
@@ -47,6 +48,7 @@ func New(
 		binPackFirstFitWeight:         binPackFirstFitWeight,
 		startingContainerWeight:       startingContainerWeight,
 		startingContainerCountMaximum: startingContainerCountMaximum,
+		useNormalisedCellIndices:      useNormalisedCellIndices,
 	}
 }
 
@@ -77,7 +79,7 @@ func (a *auctionRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) err
 			logger.Info("fetching-zone-state")
 			fetchStatesStartTime := time.Now()
 			// Add a use cell index normalization boolean flag
-			zones := FetchStateAndBuildZones(logger, a.workPool, clients, a.metricEmitter, false)
+			zones := FetchStateAndBuildZones(logger, a.workPool, clients, a.metricEmitter, a.useNormalisedCellIndices)
 			fetchStateDuration := time.Since(fetchStatesStartTime)
 			err = a.metricEmitter.FetchStatesCompleted(fetchStateDuration)
 			if err != nil {

--- a/auctionrunner/auction_runner.go
+++ b/auctionrunner/auction_runner.go
@@ -23,7 +23,6 @@ type auctionRunner struct {
 	binPackFirstFitWeight         float64
 	startingContainerWeight       float64
 	startingContainerCountMaximum int
-	useNormalisedCellIndices      bool
 }
 
 func New(
@@ -35,7 +34,6 @@ func New(
 	binPackFirstFitWeight float64,
 	startingContainerWeight float64,
 	startingContainerCountMaximum int,
-	useNormalisedCellIndices bool,
 ) *auctionRunner {
 	return &auctionRunner{
 		logger:                        logger,
@@ -47,7 +45,6 @@ func New(
 		binPackFirstFitWeight:         binPackFirstFitWeight,
 		startingContainerWeight:       startingContainerWeight,
 		startingContainerCountMaximum: startingContainerCountMaximum,
-		useNormalisedCellIndices:      useNormalisedCellIndices,
 	}
 }
 
@@ -77,7 +74,7 @@ func (a *auctionRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) err
 
 			logger.Info("fetching-zone-state")
 			fetchStatesStartTime := time.Now()
-			zones := FetchStateAndBuildZones(logger, a.workPool, clients, a.metricEmitter, a.useNormalisedCellIndices)
+			zones := FetchStateAndBuildZones(logger, a.workPool, clients, a.metricEmitter, a.binPackFirstFitWeight)
 			fetchStateDuration := time.Since(fetchStatesStartTime)
 			err = a.metricEmitter.FetchStatesCompleted(fetchStateDuration)
 			if err != nil {

--- a/auctionrunner/auction_runner.go
+++ b/auctionrunner/auction_runner.go
@@ -32,6 +32,7 @@ func New(
 	clock clock.Clock,
 	workPool *workpool.WorkPool,
 	binPackFirstFitWeight float64,
+	// Add a use cell index normalization boolean flag
 	startingContainerWeight float64,
 	startingContainerCountMaximum int,
 ) *auctionRunner {
@@ -75,7 +76,8 @@ func (a *auctionRunner) Run(signals <-chan os.Signal, ready chan<- struct{}) err
 
 			logger.Info("fetching-zone-state")
 			fetchStatesStartTime := time.Now()
-			zones := FetchStateAndBuildZones(logger, a.workPool, clients, a.metricEmitter)
+			// Add a use cell index normalization boolean flag
+			zones := FetchStateAndBuildZones(logger, a.workPool, clients, a.metricEmitter, false)
 			fetchStateDuration := time.Since(fetchStatesStartTime)
 			err = a.metricEmitter.FetchStatesCompleted(fetchStateDuration)
 			if err != nil {

--- a/auctionrunner/cell.go
+++ b/auctionrunner/cell.go
@@ -12,6 +12,7 @@ type Cell struct {
 	Guid   string
 	client rep.Client
 	state  rep.CellState
+	Index  int
 
 	workToCommit rep.Work
 }
@@ -22,6 +23,7 @@ func NewCell(logger lager.Logger, guid string, client rep.Client, state rep.Cell
 		Guid:         guid,
 		client:       client,
 		state:        state,
+		Index:        state.CellIndex,
 		workToCommit: rep.Work{CellID: guid},
 	}
 }
@@ -46,7 +48,7 @@ func (c *Cell) State() rep.CellState {
 	return c.state
 }
 
-func (c *Cell) ScoreForLRP(lrp *rep.LRP, startingContainerWeight float64, binPackFirstFitWeight float64) (float64, error) {
+func (c *Cell) ScoreForLRP(lrp *rep.LRP, startingContainerWeight, binPackFirstFitWeight float64) (float64, error) {
 	proxiedLRP := rep.Resource{
 		MemoryMB: lrp.Resource.MemoryMB + int32(c.state.ProxyMemoryAllocationMB),
 		DiskMB:   lrp.Resource.DiskMB,
@@ -69,7 +71,7 @@ func (c *Cell) ScoreForLRP(lrp *rep.LRP, startingContainerWeight float64, binPac
 
 	resourceScore := c.state.ComputeScore(&proxiedLRP, startingContainerWeight)
 
-	indexScore := float64(c.state.CellIndex) * binPackFirstFitWeight
+	indexScore := float64(c.Index) * binPackFirstFitWeight
 
 	c.logger.Debug("score-for-lrp", lager.Data{
 		"cell-guid":      c.Guid,

--- a/auctionrunner/cell_test.go
+++ b/auctionrunner/cell_test.go
@@ -149,9 +149,9 @@ var _ = Describe("Cell", func() {
 				instance = BuildLRP("pg-0", "domain", 0, linuxRootFSURL, 20, 20, 10, []string{})
 
 				cellStateZero = BuildCellState(
-					"cellID",
+					"diego-cell/a",
 					0,
-					"the-zone",
+					"z1",
 					100,
 					200,
 					50,
@@ -169,9 +169,9 @@ var _ = Describe("Cell", func() {
 				cellZero = auctionrunner.NewCell(logger, "cell-0", client, cellStateZero)
 
 				cellStateOne = BuildCellState(
-					"cellID",
+					"diego-cell/b",
 					1,
-					"the-zone",
+					"z2",
 					100,
 					200,
 					50,
@@ -221,6 +221,20 @@ var _ = Describe("Cell", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(cellZeroScore).To(BeNumerically("==", cellOneScore), "ignore Bin Pack First Fit algorithm")
+			})
+
+			It("prefers normalised cell indices", func() {
+				binPackFirstFitWeight := 1.0
+
+				cellZero.Index = 0
+				cellZeroScore, err := cellZero.ScoreForLRP(instance, 0.0, binPackFirstFitWeight)
+				Expect(err).NotTo(HaveOccurred())
+
+				cellOne.Index = 0
+				cellOneScore, err := cellOne.ScoreForLRP(instance, 0.0, binPackFirstFitWeight)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(cellZeroScore).To(BeNumerically("==", cellOneScore), "has a separate normalised cell ordering for each zone")
 			})
 		})
 

--- a/auctionrunner/cell_test.go
+++ b/auctionrunner/cell_test.go
@@ -148,44 +148,12 @@ var _ = Describe("Cell", func() {
 			BeforeEach(func() {
 				instance = BuildLRP("pg-0", "domain", 0, linuxRootFSURL, 20, 20, 10, []string{})
 
-				cellStateZero = BuildCellState(
-					"the-zone",
-					0,
-					"z1",
-					100,
-					200,
-					50,
-					false,
-					0,
-					linuxOnlyRootFSProviders,
-					[]rep.LRP{
-						*BuildLRP("pg-1", "domain", 0, linuxRootFSURL, 20, 20, 10, []string{}),
-					},
-					[]string{},
-					[]string{},
-					[]string{},
-					0,
-				)
+				cellZeroLRPs := []rep.LRP{*BuildLRP("pg-1", "domain", 0, linuxRootFSURL, 20, 20, 10, []string{})}
+				cellStateZero = BuildCellState("cellID", 0, "the-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, cellZeroLRPs, []string{}, []string{}, []string{}, 0)
 				cellZero = auctionrunner.NewCell(logger, "cell-0", client, cellStateZero)
 
-				cellStateOne = BuildCellState(
-					"the-zone",
-					1,
-					"z2",
-					100,
-					200,
-					50,
-					false,
-					0,
-					linuxOnlyRootFSProviders,
-					[]rep.LRP{
-						*BuildLRP("pg-2", "domain", 0, linuxRootFSURL, 20, 20, 10, []string{}),
-					},
-					[]string{},
-					[]string{},
-					[]string{},
-					0,
-				)
+				cellOneLRPs := []rep.LRP{*BuildLRP("pg-2", "domain", 0, linuxRootFSURL, 20, 20, 10, []string{})}
+				cellStateOne = BuildCellState("cellID", 1, "other-zone", 100, 200, 50, false, 0, linuxOnlyRootFSProviders, cellOneLRPs, []string{}, []string{}, []string{}, 0)
 				cellOne = auctionrunner.NewCell(logger, "cell-1", client, cellStateOne)
 			})
 

--- a/auctionrunner/cell_test.go
+++ b/auctionrunner/cell_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Cell", func() {
 				instance = BuildLRP("pg-0", "domain", 0, linuxRootFSURL, 20, 20, 10, []string{})
 
 				cellStateZero = BuildCellState(
-					"diego-cell/a",
+					"the-zone",
 					0,
 					"z1",
 					100,
@@ -169,7 +169,7 @@ var _ = Describe("Cell", func() {
 				cellZero = auctionrunner.NewCell(logger, "cell-0", client, cellStateZero)
 
 				cellStateOne = BuildCellState(
-					"diego-cell/b",
+					"the-zone",
 					1,
 					"z2",
 					100,

--- a/auctionrunner/scheduler.go
+++ b/auctionrunner/scheduler.go
@@ -43,7 +43,7 @@ func (z *Zone) filterCells(pc rep.PlacementConstraint) ([]*Cell, error) {
 func (z Zone) Len() int      { return len(z) }
 func (z Zone) Swap(i, j int) { z[i], z[j] = z[j], z[i] }
 func (z Zone) Less(i, j int) bool {
-	return z[i].State().CellID < z[j].State().CellID
+	return z[i].State().CellIndex < z[j].State().CellIndex
 }
 
 type Scheduler struct {

--- a/auctionrunner/scheduler.go
+++ b/auctionrunner/scheduler.go
@@ -40,6 +40,12 @@ func (z *Zone) filterCells(pc rep.PlacementConstraint) ([]*Cell, error) {
 	return cells, err
 }
 
+func (z Zone) Len() int      { return len(z) }
+func (z Zone) Swap(i, j int) { z[i], z[j] = z[j], z[i] }
+func (z Zone) Less(i, j int) bool {
+	return z[i].State().CellID < z[j].State().CellID
+}
+
 type Scheduler struct {
 	workPool                      *workpool.WorkPool
 	zones                         map[string]Zone
@@ -296,8 +302,12 @@ func (s *Scheduler) scheduleLRPAuction(lrpAuction *auctiontypes.LRPAuction) (*au
 
 	cellStates := map[string]CellResourceState{}
 
+	// Build the zone index registry
+
 	for zoneIndex, lrpByZone := range sortedZones {
 		for _, cell := range lrpByZone.zone {
+			// Take the index and pass it to the scoreForLRP
+
 			score, err := cell.ScoreForLRP(&lrpAuction.LRP, s.startingContainerWeight, s.binPackFirstFitWeight)
 			if err != nil {
 				cellStates[cell.Guid] = NewCellResourceState(cell.State())

--- a/auctionrunner/scheduler.go
+++ b/auctionrunner/scheduler.go
@@ -302,12 +302,8 @@ func (s *Scheduler) scheduleLRPAuction(lrpAuction *auctiontypes.LRPAuction) (*au
 
 	cellStates := map[string]CellResourceState{}
 
-	// Build the zone index registry
-
 	for zoneIndex, lrpByZone := range sortedZones {
 		for _, cell := range lrpByZone.zone {
-			// Take the index and pass it to the scoreForLRP
-
 			score, err := cell.ScoreForLRP(&lrpAuction.LRP, s.startingContainerWeight, s.binPackFirstFitWeight)
 			if err != nil {
 				cellStates[cell.Guid] = NewCellResourceState(cell.State())

--- a/simulation/simulation_suite_test.go
+++ b/simulation/simulation_suite_test.go
@@ -34,6 +34,8 @@ const linuxStack = "linux"
 
 const numCells = 100
 
+var numZones = 2
+
 var cells map[string]rep.SimClient
 
 var repResources = rep.Resources{
@@ -110,6 +112,7 @@ var _ = BeforeEach(func() {
 		0.0,
 		0.25,
 		defaultMaxContainerStartCount,
+		false,
 	)
 	runnerProcess = ifrit.Invoke(runner)
 })
@@ -131,7 +134,7 @@ func cellGuid(index int) string {
 }
 
 func zone(index int) string {
-	return fmt.Sprintf("Z%d", index%2)
+	return fmt.Sprintf("Z%d", index%numZones)
 }
 
 func buildInProcessReps() map[string]rep.SimClient {

--- a/simulation/simulation_suite_test.go
+++ b/simulation/simulation_suite_test.go
@@ -112,7 +112,6 @@ var _ = BeforeEach(func() {
 		0.0,
 		0.25,
 		defaultMaxContainerStartCount,
-		false,
 	)
 	runnerProcess = ifrit.Invoke(runner)
 })

--- a/simulation/simulation_test.go
+++ b/simulation/simulation_test.go
@@ -3,7 +3,6 @@ package simulation_test
 import (
 	"fmt"
 	"math"
-	"sort"
 	"sync"
 	"time"
 
@@ -129,7 +128,7 @@ var _ = Describe("Auction", func() {
 		assertSampleDistributionTolerances(distroVector, tolerance)
 	}
 
-	getZonesOrderedByCellID := func(numCells int, finalDistributions map[string]float64) map[int][]string {
+	getZones := func(numCells int, finalDistributions map[string]float64) map[int][]string {
 		zones := map[int][]string{}
 
 		for zoneIdx := 0; zoneIdx < numZones; zoneIdx++ {
@@ -138,8 +137,6 @@ var _ = Describe("Auction", func() {
 			for i := zoneIdx; i < numCells; i += numZones {
 				zones[zoneIdx] = append(zones[zoneIdx], cellGuid(i))
 			}
-
-			sort.Strings(zones[zoneIdx])
 		}
 
 		return zones
@@ -274,7 +271,7 @@ var _ = Describe("Auction", func() {
 
 								finalDistributions := getFinalDistributions()
 
-								zones := getZonesOrderedByCellID(ncells[i], finalDistributions)
+								zones := getZones(ncells[i], finalDistributions)
 								for _, zone := range zones {
 									assertNonDecreasingMonotonicSample(zone, finalDistributions)
 								}


### PR DESCRIPTION
## Please provide the following information:

### What is this change about?

Introduction of a cell index normalisation mechanism to be used when `diego.auctioneer.bin_pack_first_fit_weight` > 0.

It could be enabled by setting `diego.auctioneer.use_cell_index_normalisation` to `true`. Index normalisation is decoupled from standard bin pack first fit distribution since it changes how the weight should be configured.

💡 Note - When cell index normalisation is used, in order to keep the distribution the same as before the old value of `diego.auctioneer.bin_pack_first_fit_weight` should be multiplied by `number of zones`.

### What problem it is trying to solve?

The way bin pack first-fit app distribution is currently implemented causes a misbalance in regard to cell resource utilisation between AZs when:

- there has been an upscale of the number of zones in BOSH
- `diego.auctioneer.bin_pack_first_fit_weight` > 0.

This results in stability issues (e.g. if the more utilised zone fails due to IaaS issues it could cause a longer outage).

### What is the impact if the change is not made?

There would be "silent" stability issues after a CF operator tries to upscale bosh availability zones while using a bin pack first-fit distribution.

### How should this change be described in diego-release release notes?

Introduce new cell indexing concept

### Please provide any contextual information.

All details, including a RC and an exact reproduction scenario could be found in [diego-release issue 542](https://github.com/cloudfoundry/diego-release/issues/542).

### Tag your pair, your PM, and/or team!

Just me -> [Ivan Hristov](https://github.com/IvanHristov98)
PM -> [Plamen Doychev](https://github.com/PlamenDoychev)
CF-Runtime team at SAP.
